### PR TITLE
Implement lat, lon, location fields to Earthquake search/results

### DIFF
--- a/src/main/java/earthquakes/controllers/EarthquakesController.java
+++ b/src/main/java/earthquakes/controllers/EarthquakesController.java
@@ -36,7 +36,7 @@ public class EarthquakesController {
            new EarthquakeQueryService();
 
         model.addAttribute("eqSearch", eqSearch);
-        String json = e.getJSON(eqSearch.getDistance(), eqSearch.getMinmag());
+        String json = e.getJSON(eqSearch.getDistance(), eqSearch.getMinmag(), eqSearch.getLat(), eqSearch.getLon());
         model.addAttribute("json", json);
         FeatureCollection featureCollection = FeatureCollection.fromJSON(json);
         model.addAttribute("featureCollection",featureCollection);

--- a/src/main/java/earthquakes/searches/EqSearch.java
+++ b/src/main/java/earthquakes/searches/EqSearch.java
@@ -3,6 +3,8 @@ package earthquakes.searches;
 public class EqSearch {
     private int distance;
     private int minmag;
+    private double lat, lon;
+    private String location;
 
     public EqSearch(){
 
@@ -10,7 +12,14 @@ public class EqSearch {
 
     public int getDistance() { return distance; }
     public int getMinmag() { return minmag; }
+    public double getLat() { return lat; }
+    public double getLon() { return lon; }
+    public String getLocation() { return location; }
 
     public void setDistance(int dist) { distance = dist; }
     public void setMinmag(int mm) { minmag = mm; }
+    public void setLat(double la) { lat = la; }
+    public void setLon(double lo) { lon = lo; }
+    public void setLocation(String loc) { location = loc; }
+
 }

--- a/src/main/java/earthquakes/services/EarthquakeQueryService.java
+++ b/src/main/java/earthquakes/services/EarthquakeQueryService.java
@@ -23,7 +23,7 @@ public class EarthquakeQueryService {
 
     private Logger logger = LoggerFactory.getLogger(EarthquakeQueryService.class);
 
-    public String getJSON(int distance, int minmag) {
+    public String getJSON(int distance, int minmag, double lat, double lon) {
         RestTemplate restTemplate = new RestTemplate();
 
         HttpHeaders headers = new HttpHeaders();
@@ -33,8 +33,10 @@ public class EarthquakeQueryService {
         HttpEntity<String> entity = new HttpEntity("body", headers);
 
         String uri = "https://earthquake.usgs.gov/fdsnws/event/1/query";
-        double ucsbLat = 34.4140;
-        double ucsbLong = -119.8489;
+        // double ucsbLat = 34.4140;
+        // double ucsbLong = -119.8489;
+        double ucsbLat = lat;
+        double ucsbLong = lon;
         String params = String.format("?format=geojson&minmagnitude=%d&maxradiuskm=%d&latitude=%f&longitude=%f",
            minmag,distance,ucsbLat,ucsbLong);
 

--- a/src/main/resources/templates/earthquakes/results.html
+++ b/src/main/resources/templates/earthquakes/results.html
@@ -12,38 +12,27 @@
 
     <h1>Earthquake Search Results</h1>
 
-    <h2> Results</h2>
-
-    <table class="table">
-      <thead>
-        <tr>
-          <th>Type</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td th:text="${featureCollection.type}"></td>
-        </tr>
-      </tbody>
-    </table>
-
     <table class = "table">
       <thead>
         <tr>
           <th>Title</th>
-          <th>Url</th>
           <th>Count</th>
           <th>Distance (km)</th>
           <th>Minimum Magnitude</th>
+          <th>Latitude</th>
+          <th>Longitude</th>
+          <th>Location</th>
         </tr>
       </thead>
       <tbody>
         <tr>
-          <td><a th:href="${featureCollection.metadata.url}" th:text="${featureCollection.metadata.title}"></a></td>
-          <td th:text="${featureCollection.metadata.url}"></td>
+          <td th:text="${featureCollection.metadata.title}"></td>
           <td th:text="${featureCollection.metadata.count}"></td>
           <td th:text="${eqSearch.distance}"></td>
           <td th:text="${eqSearch.minmag}"></td>
+          <td th:text="${eqSearch.lat}"></td>
+          <td th:text="${eqSearch.lon}"></td>
+          <td th:text="${eqSearch.location}"></td>
         </tr>
       </tbody>
     </table>
@@ -52,7 +41,6 @@
     <table class="table">
       <thead>
         <tr>
-          <th>title</th>
           <th>id</th>
           <th>place</th>
           <th>mag</th>
@@ -60,7 +48,6 @@
       </thead>
       <tbody>
         <tr th:each="f: ${featureCollection.features}">
-          <td th:text="${f.properties.title}"></td>
           <td><a th:href="${f.properties.url}" th:text="${f.id}"></a></td>
           <td th:text="${f.properties.place}"></td>
           <td th:text="${f.properties.mag}"></td>

--- a/src/main/resources/templates/earthquakes/search.html
+++ b/src/main/resources/templates/earthquakes/search.html
@@ -30,6 +30,30 @@
             <input type="number" th:field="*{minmag}" class="form-control" id="minmag" />
           </td>
         </tr>
+        <tr class="form-group">
+          <th>
+            <label for="lat" class="col-form-label">Latitude</label>
+          </th>
+          <td>
+            <input type="number" step="any" th:field="*{lat}" class="form-control" id="lat" />
+          </td>
+        </tr>
+        <tr class="form-group">
+          <th>
+            <label for="lon" class="col-form-label">Longitude</label>
+          </th>
+          <td>
+            <input type="number" step="any" th:field="*{lon}" class="form-control" id="lon" />
+          </td>
+        </tr>
+        <tr class="form-group">
+          <th>
+            <label for="location" class="col-form-label">Location</label>
+          </th>
+          <td>
+            <input type="text" th:field="*{location}" class="form-control" id="location" />
+          </td>
+        </tr>
       </table>
 
       <input type="submit" class="btn btn-primary" value="Search" />


### PR DESCRIPTION
In this PR, we get rid of the hard-coded functionality of our lat and long fields in the earthquake search and now allow user input for these fields including specifying the location which we still need to link.