### PR TITLE
Add link to Earthquake Results from Location Search

### DIFF
--- a/src/main/resources/templates/locations/results.html
+++ b/src/main/resources/templates/locations/results.html
@@ -35,6 +35,7 @@
           <th>Longitude</th>
           <th>Display Name</th>
           <th>Type</th>
+          <th>Get Earthquakes</th>
         </tr>
       </thead>
       <tbody>
@@ -44,6 +45,7 @@
           <td th:text="${p.lon}"></td>
           <td th:text="${p.display_name}"></td>
           <td th:text="${p.type}"></td>
+          <td><a th:href="@{/earthquakes/search/(lat=${p.lat},lon=${p.lon},location=${p.display_name})}">Get Earthquakes</a></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
In this PR, we add a link to the results page of the Location Search in the table that links to the Earthquake search with the given location (inputs lat, lon, and location fields) in the search.